### PR TITLE
Add timeout parameter to Validate API

### DIFF
--- a/api.go
+++ b/api.go
@@ -133,12 +133,15 @@ func (v ApiUsageResponse) EndDate() (time.Time, error) {
 }
 
 // Validate validates a single email
-func Validate(email string, IPAddress string) (*ValidateResponse, error) {
+func Validate(email string, IPAddress string, Timeout *string) (*ValidateResponse, error) {
 
 	// Prepare the parameters
 	params := url.Values{}
 	params.Set("email", email)
 	params.Set("ip_address", IPAddress)
+	if Timeout != nil {
+		params.Set("timeout", *Timeout)
+	}
 
 	response := &ValidateResponse{}
 

--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -8,7 +8,10 @@ func TestValidate(t *testing.T) {
 	Initialize("mock_key")
 	for _, e := range emailsToValidate {
 
-		r, err := Validate(e.Email, SANDBOX_IP)
+		r, err := Validate(e.Email, SANDBOX_IP, func() *string {
+			v := "10" // timeout seconds
+			return &v
+		}())
 		if err != nil {
 			t.Errorf(err.Error())
 		}

--- a/validate_test.go
+++ b/validate_test.go
@@ -104,7 +104,7 @@ func TestMockValidationNoApiKeySet(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	mockValidateRequest()
 
-	_, error_ := Validate("valid@example.com", SANDBOX_IP)
+	_, error_ := Validate("valid@example.com", SANDBOX_IP, nil)
 	assert.NotNil(t, error_)
 	assert.Contains(t, error_.Error(), "api_key")
 }
@@ -117,7 +117,7 @@ func TestMockValidationOk(t *testing.T) {
 	mockValidateRequest()
 
 	for _, test_case := range emailsToValidate {
-		email_response, error_ := Validate(test_case.Email, SANDBOX_IP)
+		email_response, error_ := Validate(test_case.Email, SANDBOX_IP, nil)
 		assert.Nil(t, error_)
 		assert.Equalf(t, test_case.Status, email_response.Status, "failed for email %s", email_response.Address)
 		assert.Equalf(t, test_case.SubStatus, email_response.SubStatus, "failed for email %s", email_response.Address)


### PR DESCRIPTION
Add the ability to utilize the `timeout` parameter for the validate API.